### PR TITLE
Support for adding new HTTP headers

### DIFF
--- a/lib/sockjs-client.js
+++ b/lib/sockjs-client.js
@@ -52,7 +52,10 @@
         };
     }());
 
-    function SockJSClient (server) {
+    function SockJSClient (server, addedHeaders) {
+
+        this.addedHeaders = addedHeaders;
+
         var parsed, serverId, sessionId;
 
         parsed = url.parse(server);
@@ -185,6 +188,9 @@
             var request = {method: 'POST',
                            headers: {'Content-Length': 0}},
                 clientRequest;
+            for (var addedHeader in this.sjs.addedHeaders) {
+                request.headers[addedHeader] = this.sjs.addedHeaders[addedHeader];
+            }
             util.shallowCopy(this.sjs.server, request);
             request.path += '/xhr_streaming';
             clientRequest = this.sjs.client.request(request, sm.stepper());
@@ -199,6 +205,9 @@
                                'Content-Type': 'application/json',
                                'Content-Length': Buffer.byteLength(data,'utf8')}},
                 clientRequest;
+            for (var addedHeader in this.sjs.addedHeaders) {
+                request.headers[addedHeader] = this.sjs.addedHeaders[addedHeader];
+            }
             util.shallowCopy(this.sjs.server, request);
             request.path += '/xhr_send';
             clientRequest = this.sjs.client.request(request);
@@ -368,8 +377,8 @@
         }
     };
 
-    exports.create = function (url) {
-        var sjsc = new SockJSClient(url);
+    exports.create = function (url, addedHeaders) {
+        var sjsc = new SockJSClient(url, addedHeaders);
         sjsc.connect();
         return sjsc;
     };


### PR DESCRIPTION
These changes allow for the inclusion of a new parameter in the
SockJSClient, such that additional HTTP header fields may be defined in
a form of an object. Any existing predefined header fields in code will
be overwritten with the specified HTTP header field of the same header
name (key).  The added headers will be appended onto both the ‘start’
and ‘write’ request variables of XHRStreaming.prototype.
